### PR TITLE
Add GitHub repository link

### DIFF
--- a/package.json
+++ b/package.json
@@ -5,6 +5,10 @@
   "author": "Jeffrey van den Hondel",
   "license": "MIT",
   "main": "lib/index.js",
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/jeffreyvdhondel/gridsome-source-confluence.git"
+  },
   "files": [
     "lib"
   ],


### PR DESCRIPTION
This page missing link: https://gridsome.org/plugins/gridsome-source-confluence
Example of proper one: https://gridsome.org/plugins/gridsome-remark-embed-snippet
Give option to be automatically used in many systems